### PR TITLE
fix Nasa API call

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -3,18 +3,18 @@ var searchButton = document.getElementById("searchButton");
 var starCheck = document.getElementById("starCheck");
 var planetCheck = document.getElementById("planetCheck");
 var infoSection = document.getElementById("infoSection");
-var image1Section=document.getElementById("image1");
-var image2Section= document.getElementById("image2");
-var image3Section= document.getElementById("image3");
+var image1Section = document.getElementById("image1");
+var image2Section = document.getElementById("image2");
+var image3Section = document.getElementById("image3");
 
 //loads background on page open
-window.addEventListener("load", function (){
-    fetch(
-      "https://api.nasa.gov/planetary/apod?api_key=NhPFpaLICBNtgWJTI0edILu5U5CcPKT8T4Fd2w2l" )
-      .then((response) => response.json())
-      .then((data) => {
-        document.body.style.backgroundImage = `url("${data.url}")`;
-        })
+window.addEventListener("load", function () {
+  fetch(
+    "https://api.nasa.gov/planetary/apod?api_key=NhPFpaLICBNtgWJTI0edILu5U5CcPKT8T4Fd2w2l")
+    .then((response) => response.json())
+    .then((data) => {
+      document.body.style.backgroundImage = `url("${data.url}")`;
+    })
 })
 
 //fetch for planet and Stars
@@ -29,21 +29,21 @@ window.addEventListener("load", function (){
 
 
 
-planetCheck.addEventListener("click", function(){
-    if (this.click) {
-      planetCheck.value = true;
-      starCheck.value = false;
-    } 
+planetCheck.addEventListener("click", function () {
+  if (this.click) {
+    planetCheck.value = true;
+    starCheck.value = false;
+  }
 })
 
-starCheck.addEventListener("click", function() {
-  if(this.click){
+starCheck.addEventListener("click", function () {
+  if (this.click) {
     starCheck.value = true;
     planetCheck.value = false;
   }
 })
 
-function fetchStar(input){
+function fetchStar(input) {
   starUrl = "https://api.api-ninjas.com/v1/stars?name=" + input;
   fetch(input, {
     method: 'GET',
@@ -52,8 +52,8 @@ function fetchStar(input){
       'Content-Type': "application/json",
     },
   })
-  .then(function (response) {
-    return response.json();
+    .then(function (response) {
+      return response.json();
     })
     .then(function (data) {
       console.log(data);
@@ -62,10 +62,10 @@ function fetchStar(input){
       var distanceLY = document.createElement("p");
       var declination = document.createElement("p");
 
-      nameStar.textContent="Star: " + data[0].name;
-      constellation.textContent ="constellation: " + data[0].constellation;
-      distanceLY.textContent= "Distance In Light Years: " + data[0].distance_light_year;
-      declination.textContent= "Declination: " + data[0].declination;
+      nameStar.textContent = "Star: " + data[0].name;
+      constellation.textContent = "constellation: " + data[0].constellation;
+      distanceLY.textContent = "Distance In Light Years: " + data[0].distance_light_year;
+      declination.textContent = "Declination: " + data[0].declination;
 
       infoSection.appendChild(nameStar);
       infoSection.appendChild(constellation);
@@ -75,12 +75,12 @@ function fetchStar(input){
 
     });
 
-  }
+}
 
 
-function fetchPlanet(input){
-  infoSection.textContent="";
-  planetUrl= "https://api.api-ninjas.com/v1/planets?name=" + input;
+function fetchPlanet(input) {
+  infoSection.textContent = "";
+  planetUrl = "https://api.api-ninjas.com/v1/planets?name=" + input;
   fetch(planetUrl, {
     method: 'GET',
     headers: {
@@ -88,70 +88,81 @@ function fetchPlanet(input){
       'Content-Type': "application/json",
     },
   })
-  .then(function (response) {
-    return response.json();
-  })
-  
-  .then(function (data) {
-    console.log(data);
-    var namePlanet=document.createElement("h5");
-    var distanceLy= document.createElement("p");
-    var mass = document.createElement("p");
-    var temperature = document.createElement("p");
-    var period = document.createElement("p");
+    .then(function (response) {
+      return response.json();
+    })
 
-    namePlanet.textContent="Planet: "+data[0].name;
-    distanceLy.textContent="Distance in Light Years from Earth: "+ data[0].distance_light_year;
-    mass.textContent="Total Mass of planet: " + data[0].mass;
-    temperature.textContent="Temperature: " + data[0].temperature;
-    period.textContent= data[0].period + " " + data[0].name + " day is 1 yeah on earth ";
+    .then(function (data) {
+      console.log(data);
+      var namePlanet = document.createElement("h5");
+      var distanceLy = document.createElement("p");
+      var mass = document.createElement("p");
+      var temperature = document.createElement("p");
+      var period = document.createElement("p");
 
-    infoSection.appendChild(namePlanet);
-    infoSection.appendChild(distanceLy);
-    infoSection.appendChild(mass);
-    infoSection.appendChild(temperature);
-    infoSection.appendChild(period);
-  });
-  }
+      namePlanet.textContent = "Planet: " + data[0].name;
+      distanceLy.textContent = "Distance in Light Years from Earth: " + data[0].distance_light_year;
+      mass.textContent = "Total Mass of planet: " + data[0].mass;
+      temperature.textContent = "Temperature: " + data[0].temperature;
+      period.textContent = data[0].period + " " + data[0].name + " day is 1 yeah on earth ";
+
+      infoSection.appendChild(namePlanet);
+      infoSection.appendChild(distanceLy);
+      infoSection.appendChild(mass);
+      infoSection.appendChild(temperature);
+      infoSection.appendChild(period);
+    });
+}
 
 
-function fetchNasa(input){
-  var nasaUrl="https://images-api.nasa.gov/search?q="+ input + "&media_type=image";
-  fetch(nasaUrl)
-  .then(function (response) {
-         return response.json();
-     })
+async function fetchNasa(input) {
+  let results;
+  let baseNasaUrl = "https://images-api.nasa.gov/search?q=" + input + "&media_type=image"
+
+  await fetch(baseNasaUrl + "&keywords=planet")
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (data) {
+      results = data.collection.items
+    });
+
+
+  if (results.length < 3) {
+    fetch(baseNasaUrl)
+      .then(function (response) {
+        return response.json();
+      })
       .then(function (data) {
-         console.log(data);
-        image1Section.textContent="";
-        image2Section.textContent="";
-        image3Section.textContent="";
-        var image1 = document.createElement("img");
-        var image2 = document.createElement("img");
-        var image3 = document.createElement("img");
-
-        image1.setAttribute("src",data.collection.items[0].links[0].href);
-        image2.setAttribute("src",data.collection.items[1].links[0].href);
-        image3.setAttribute("src",data.collection.items[2].links[0].href);
-        image1Section.appendChild(image1);
-        image2Section.appendChild(image2);
-        image3Section.appendChild(image3);
-
-
-     });
+        results = data.collection.items
+      });
   }
+  image1Section.textContent = "";
+  image2Section.textContent = "";
+  image3Section.textContent = "";
+  var image1 = document.createElement("img");
+  var image2 = document.createElement("img");
+  var image3 = document.createElement("img");
+
+  image1.setAttribute("src", results[0].links[0].href);
+  image2.setAttribute("src", results[1].links[0].href);
+  image3.setAttribute("src", results[2].links[0].href);
+  image1Section.appendChild(image1);
+  image2Section.appendChild(image2);
+  image3Section.appendChild(image3);
+}
 
 
 
-  // fetchNasa();
+// fetchNasa();
 // searchButton.addEventListener('click', fetchPlanet("mars"));
 
 
-searchButton.addEventListener("click", function() {
-  if(planetCheck.value=="on"){
+searchButton.addEventListener("click", function () {
+  if (planetCheck.value == "on") {
     fetchPlanet(userInput.value);
     fetchNasa(userInput.value);
-  }else if(starCheck.value=="on"){
+  } else if (starCheck.value == "on") {
     fetchStar(userInput.value);
   }
 })
@@ -167,8 +178,8 @@ searchButton.addEventListener("click", function() {
 
 
 
-var testUrl= "https://api.api-ninjas.com/v1/stars?name=vega";
-var testUrl1= "https://api.api-ninjas.com/v1/planets?name=Mars"
+var testUrl = "https://api.api-ninjas.com/v1/stars?name=vega";
+var testUrl1 = "https://api.api-ninjas.com/v1/planets?name=Mars"
   // fetchStar(testUrl);
   // fetchPlanet(testUrl1);
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -127,26 +127,26 @@ function fetchPlanet(input){
   }
 
 //add 3 images from the nasa database to the display
-function fetchNasa(input){
-  var nasaUrl="https://images-api.nasa.gov/search?q="+ input + "&media_type=image";
-  fetch(nasaUrl)
+async function fetchNasa(input) {
+  let results;
+  let baseNasaUrl = "https://images-api.nasa.gov/search?q=" + input + "&media_type=image"
+
+  await fetch(baseNasaUrl + "&keywords=planet")
   .then(function (response) {
          return response.json();
      })
       .then(function (data) {
-         console.log(data);
-        var image1 = document.createElement("img");
-        var image2 = document.createElement("img");
-        var image3 = document.createElement("img");
-
-        image1.setAttribute("src",data.collection.items[0].links[0].href);
-        image2.setAttribute("src",data.collection.items[1].links[0].href);
-        image3.setAttribute("src",data.collection.items[2].links[0].href);
-        image1Section.appendChild(image1);
-        image2Section.appendChild(image2);
-        image3Section.appendChild(image3);
+      results = data.collection.items
+    });
 
 
+  if (results.length < 3) {
+    fetch(baseNasaUrl)
+      .then(function (response) {
+        return response.json();
+      })
+      .then(function (data) {
+        results = data.collection.items
      });
   }
   image1Section.textContent = "";

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -141,7 +141,7 @@ async function fetchNasa(input) {
 
 
   if (results.length < 3) {
-    fetch(baseNasaUrl)
+    await fetch(baseNasaUrl)
       .then(function (response) {
         return response.json();
       })


### PR DESCRIPTION
this code fixed the Nasa API call.

we first call the API with the user's input and a refined search parameter (keywords=planets). This is to restrict the images returned to only relevant ones - planets, surfaces, celestial bodies - and not random/irrelevant results like cosplayers and scientists.

if this restricted API call returns fewer than 3 results, we fetch again with broader query params.